### PR TITLE
hotfix(version) : change version comparaison 

### DIFF
--- a/learn-ocaml.el
+++ b/learn-ocaml.el
@@ -1107,7 +1107,7 @@ If TOKEN is \"\", interactively ask a token."
                                                   :callback
                                                   (lambda(_)
           (if (version-list-<=
-               (version-to-list (learn-ocaml-client-version)) (version-to-list "0.13"))
+              (version-to-list "0.13") (version-to-list (learn-ocaml-client-version)))
               (progn (learn-ocaml-server-config (learn-ocaml-client-config-cmd))
                      (if learn-ocaml-use-passwd
                          (learn-ocaml-login-possibly-with-passwd new-server-value callback)


### PR DESCRIPTION
Changing the version verification to give the appropriate connection choices to the user.
In fact, I had deliberately falsified the test before the release so that the connection was offered to me when the version was not yet greater than 0.12.
Maybe it will be more efficient to add some tests in order to check if the right connection choices are available.