### PR TITLE
feat(/description): Encode the token for learn-ocaml 0.13.0+ & Update (testsuite, CI)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,15 +18,8 @@ jobs:
           - learnocaml_image: "ocamlsf/learn-ocaml"
             learnocaml_version: "0.12"
             use_passwd: "false"
-            client_version: "0.12"
-            allow_failures: false
-            # may be removed at some point, when the following test will pass:
-          - learnocaml_image: "ocamlsf/learn-ocaml"
-            learnocaml_version: "0.12"
-            use_passwd: "false"
             client_version: "oauth-moodle-dev"
-            # NOTE: currently fails because of an API version mismatch
-            allow_failures: true
+            allow_failures: false
           - learnocaml_image: "pfitaxel/learn-ocaml"
             learnocaml_version: "oauth-moodle-dev"
             use_passwd: "false"

--- a/learn-ocaml.el
+++ b/learn-ocaml.el
@@ -758,10 +758,18 @@ Argument CALLBACK will receive the token."
 ;; Wrappers
 ;;
 
+(defconst learn-ocaml-compute-questions-url-token1-compat
+  (learn-ocaml-since-upto "0.13.0" nil))
+
 (defun learn-ocaml-compute-questions-url (server id token)
   "Get subject url for SERVER, exercise ID and user TOKEN."
-  ;; TODO: Use token1=
-  (concat server "/description/" id "#token=" token))
+  (let ((token-param
+         (if (learn-ocaml-compat
+              learn-ocaml-compute-questions-url-token1-compat
+              (version-to-list (learn-ocaml-client-server-min-version server)))
+             (concat "#token1=" (base64-encode-string (format "%192s" token) t))
+           (concat "#token=" token))))
+    (concat server "/description/" id token-param)))
 
 (defun learn-ocaml-show-questions (id)
   "Open the questions for exercise ID in the default browser."

--- a/tests/expected_description.html
+++ b/tests/expected_description.html
@@ -1,5 +1,1 @@
-<body>
-    <div id="learnocaml-exo-toolbar">
-       .*
-    </div>
-</body>
+<body>.*<div id="learnocaml-exo-toolbar">.*</div>.*</body>

--- a/tests/learn-ocaml-tests.el
+++ b/tests/learn-ocaml-tests.el
@@ -107,7 +107,7 @@ See also `learn-ocaml-client-sign-up-cmd'.")
     (shell-command (concat "rm -f " file))))
 
 (defun learn-ocaml-test-collapse-whitespace (str)
-  (replace-regexp-in-string "[[:space:]\n]+" " " str))
+  (string-trim (replace-regexp-in-string "[[:space:]\n]+" " " str)))
 
 (defun learn-ocaml-test-client-expected-path ()
   "Return ../../../learn-ocaml/_opam/bin


### PR DESCRIPTION
* (learn-ocaml-compute-questions-url):
  Add learn-ocaml-compute-questions-url-token1-compat
  to implement the elisp counterpart of PR
  <https://github.com/ocaml-sf/learn-ocaml/pull/423>

* .github/workflows/test.yml: Update CI as a follow-up of PRs  
  <https://github.com/ocaml-sf/learn-ocaml/pull/426>  
  <https://github.com/ocaml-sf/learn-ocaml/pull/429>